### PR TITLE
support dynamic labels in main menubar

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3,5 +3,7 @@ import ReactDOM from 'react-dom';
 import MarkdownEditor from '../src/index.js';
 
 
-ReactDOM.render(<MarkdownEditor value="ohai {name}" dynamicLabels={['name', 'email']}/>,
-  document.getElementById('editor'));
+ReactDOM.render(<div>
+  <MarkdownEditor value="ohai {name}" dynamicLabels={['name', 'email', 'blam']}/>
+</div>,
+document.getElementById('editor'));

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import React, {Component} from 'react';
 import ExecutionEnvironment from 'exenv';
-import {DynamicText, dynamicTextWithLabels} from './dynamic-text';
+import {DynamicText, dynamicTextWithLabels, dynamicMenu} from './dynamic-text';
 import {Schema, defaultSchema} from 'prosemirror/dist/model';
+import {CommandSet} from 'prosemirror/dist/edit';
+import {renderGrouped, inlineGroup, insertMenu, textblockMenu, blockGroup, historyGroup} from "prosemirror/dist/menu/menu"
 
 let ProseMirror = () => {};
 if (ExecutionEnvironment.canUseDOM) {
@@ -29,6 +31,17 @@ export default class MarkdownEditor extends Component {
       ('valueLink' in this.props && this.props.valueLink.value) ||
       this.props.defaultValue) || '';
 
+    const mainMenuBar = {
+      float: true,
+      content: [
+        inlineGroup,
+        insertMenu,
+        [textblockMenu, blockGroup],
+        historyGroup,
+        dynamicMenu,
+      ],
+    }
+
     let spec = defaultSchema.spec;
 
     if (this.props.dynamicLabels.length) {
@@ -41,7 +54,7 @@ export default class MarkdownEditor extends Component {
       place: this.refs.prosemirror,
       doc: this.val || '',
       docFormat: 'markdown',
-      menuBar: true,
+      menuBar: mainMenuBar,
       inlineMenu: true,
       buttonMenu: false,
       label: this.props.label,


### PR DESCRIPTION
![](https://dl.dropboxusercontent.com/s/r5wrmq7e0gpoeh2/CA591899-1D3B-46E8-8165-DE8E6CACDA94-2874-0002F9E23C9F72CE.gif?dl=0)

currently mutates the main DynamicText class when adding labels so they
will overlap when multiple `<MarkdownEditor />`s show up on a page.
